### PR TITLE
Enhancement #116

### DIFF
--- a/css/kort.css
+++ b/css/kort.css
@@ -91,6 +91,7 @@ h3.header {
 }
 .container {
     margin-top: 50px;
+    margin-bottom: 50px;
 }
 
 .float-right {

--- a/css/surveys.css
+++ b/css/surveys.css
@@ -11,7 +11,6 @@ body {
    background-color: #455A64;
 }
 
-
 #submitForm {
     float:left;
     font-size: 14px;
@@ -26,9 +25,13 @@ p {
     margin-bottom: 25px;
 }
 .question table td {
-    /*border: 1px solid yellow;*/
     padding-left:30px;
 }
+
+input[type='radio'] {
+    margin-left: 10px;
+}
+
 /*custom radio buttons style*/
 input[type='radio']:after {
     width: 20px;

--- a/js/nps.js
+++ b/js/nps.js
@@ -1,0 +1,25 @@
+$(document).ready(function() {
+	$('#submitForm').click(function(event) {
+		event.preventDefault();
+		var result = $('input[name=1]:checked').val();
+        var completed = true;
+        
+        if (result == null) completed = false;
+        
+        if (completed){
+        	$('#hiddenResults').val(JSON.stringify(result));
+	   		$('#npsForm').submit();
+        }
+	   	
+	});
+	// once all items have answers, enable the submit button
+	// this is one way to do validation
+	$("input").change(function(){
+    	if ($('input[name=1]:checked').val()) {
+    		$('#submitForm').removeClass("disabled");
+    	} else {
+    		$('#submitForm').addClass("disabled");
+    	}
+	});
+});
+

--- a/js/nps.js
+++ b/js/nps.js
@@ -1,25 +1,25 @@
 $(document).ready(function() {
-	$('#submitForm').click(function(event) {
-		event.preventDefault();
-		var result = $('input[name=1]:checked').val();
+    $('#submitForm').click(function(event) {
+        event.preventDefault();
+        var result = $('input[name=1]:checked').val();
         var completed = true;
         
         if (result == null) completed = false;
         
         if (completed){
-        	$('#hiddenResults').val(JSON.stringify(result));
-	   		$('#npsForm').submit();
+            $('#hiddenResults').val(JSON.stringify(result));
+               $('#npsForm').submit();
         }
-	   	
-	});
-	// once all items have answers, enable the submit button
-	// this is one way to do validation
-	$("input").change(function(){
-    	if ($('input[name=1]:checked').val()) {
-    		$('#submitForm').removeClass("disabled");
-    	} else {
-    		$('#submitForm').addClass("disabled");
-    	}
-	});
+           
+    });
+    // once all items have answers, enable the submit button
+    // this is one way to do validation
+    $("input").change(function(){
+        if ($('input[name=1]:checked').val()) {
+            $('#submitForm').removeClass("disabled");
+        } else {
+            $('#submitForm').addClass("disabled");
+        }
+    });
 });
 

--- a/js/studies.js
+++ b/js/studies.js
@@ -3,6 +3,7 @@ $(document).ready(function() {
 	$('td[data-type="cardsort"]').html('Card Sort');
 	$('td[data-type="treetest"]').html('Tree Test');
 	$('td[data-type="sus"]').html('System Usability Scale');
+	$('td[data-type="nps"]').html('Net Promoter Score');
 	$('td[data-type="productreactioncards"]').html('Product Reaction Cards');
 	$('td[data-status="open"]').html('Accepting Responses');
 	$('td[data-status="closed"]').html('Not Accepting Responses');

--- a/server/nps_server.js
+++ b/server/nps_server.js
@@ -1,0 +1,111 @@
+require('mongoose').model('Study');
+require('mongoose').model('Response');
+var mongoose = require('mongoose');
+var Study = mongoose.model('Study');
+var Response = mongoose.model('Response');
+var resp = require('./response_server');
+
+module.exports = {
+     create: function (req, res) {
+        var newStudy = new Study({
+            title: "New Net Promoter Score",
+            type: "nps",
+            dateCreated: new Date(Date.now()),
+            data: {
+                
+            },
+            status: 'closed',
+            ownerID: req.user._id,
+            private: false,
+        });
+        newStudy.save(function (err) {
+            if (err) {
+                console.log('nps_server.js: Error creating new NPS test via POST.');
+                res.status(504);
+                res.end(err);
+            } else {
+                console.log('nps_server.js: Created new NPS test via POST successfully.');
+                var fullUrl = req.protocol + '://' + req.get('host')
+                res.redirect('/editnps/'+newStudy._id+'?new=New');
+                res.end();
+            }
+        });
+    },
+    edit: function (req, res, next) {
+        Study.findOne({_id: req.params.id, ownerID: req.user._id}, function (err, docs) {
+            if (err) {
+                res.status(504);
+                console.log("nps_server.js: Error edit NPS.");
+                res.end(err);
+            } else {
+                var fullUrl = req.protocol + '://' + req.get('host');
+                res.render('nps/edit.ejs',{title: req.query.new || "Edit",singleStudy: docs, email: req.user.email, url: fullUrl});
+            }
+        });
+    },
+    results: function (req, res, next) {
+        Study.findOne({_id: req.params.id, ownerID: req.user._id}, function (err, study) {
+            if (err) {
+                res.status(504);
+                console.log("nps_server.js: Error getting study to see results.");
+                res.end(err);
+            } else {
+                const PROMOTER_SCORE_MIN = 9;
+                const DETRACTOR_SCORE_MAX = 6;
+
+                var questions = ['On a scale of 0-10, how likely are you to recommend this product or service to a friend or colleague?'];
+                var rawResponses = study.completeResponses;
+                var npsResults = [];
+
+                var npsScore = 0;
+                var promoters = 0;
+                var detractors = 0;
+                var respondents = study.completeResponses.length;
+
+                // Count the number of promoters and detractors and
+                // add a token denoting the sentiment of each response value
+                study.completeResponses.forEach(function(element) {
+                    let response = element.data[0];
+
+                    if (response <= DETRACTOR_SCORE_MAX) {
+                        detractors += 1;
+                        npsResults.push('Detractor'); 
+                    } else if (response >= PROMOTER_SCORE_MIN) {
+                        promoters += 1;
+                        npsResults.push('Promoter');
+                    } else {
+                        npsResults.push('Neutral');
+                    }
+                });
+
+                // Calculate NPS based on promoters and detractors
+                npsScore = ((promoters - detractors) / respondents) * 100;
+
+				res.render('nps/results.ejs',{study: study, 
+                                            questions: questions,
+                                            rawResponses: rawResponses,
+                                            npsResults: npsResults,
+                                            npsScore: npsScore,    
+                                            email: req.user.email});
+            }
+        });
+    },
+    update: function (req, res, next) {
+        Study.findOne({ _id: req.body.id, ownerID: req.user._id},
+            function (err, study) {
+            if (err) {
+                res.status(504);
+                console.log('nps_server.js: error updating nps');
+                res.end(err);
+            }
+            else {
+				study.title = req.body.title;
+				study.status = req.body.status;
+                study.private = req.body.private;
+				study.save();
+                res.redirect('/studies');
+                res.end();
+            }
+        });
+    },
+}

--- a/server/nps_server.js
+++ b/server/nps_server.js
@@ -81,7 +81,7 @@ module.exports = {
                 // Calculate NPS based on promoters and detractors
                 npsScore = ((promoters - detractors) / respondents) * 100;
 
-				res.render('nps/results.ejs',{study: study, 
+                res.render('nps/results.ejs',{study: study, 
                                             questions: questions,
                                             rawResponses: rawResponses,
                                             npsResults: npsResults,
@@ -99,10 +99,10 @@ module.exports = {
                 res.end(err);
             }
             else {
-				study.title = req.body.title;
-				study.status = req.body.status;
+                study.title = req.body.title;
+                study.status = req.body.status;
                 study.private = req.body.private;
-				study.save();
+                study.save();
                 res.redirect('/studies');
                 res.end();
             }

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,6 +3,7 @@ var study = require('./study_server');
 var cardsort = require('./cardsort_server');
 var treetest = require('./treetest_server');
 var sus = require('./sus_server');
+var nps = require('./nps_server');
 var productreactioncards = require('./productreactioncards_server');
 var user = require('./user_server');
 var response = require('./response_server');
@@ -52,6 +53,15 @@ module.exports = function(app, passport, flash, uploadDir) {
 	app.get('/uploadtest', isLoggedIn, function (req, res) {
 		res.render('upload.ejs',{imgpath: ""});
 	});
+
+	//nps routes
+	app.get('/createnps', isLoggedIn, nps.create);
+	app.get('/editnps/:id', isLoggedIn, nps.edit);
+	app.get('/nps/:id', study.view);
+	app.get('/nps/preview/:id', isLoggedIn, study.preview);
+	app.get('/nps/:id/:resid', study.view);
+	app.get('/npsresults/:id', isLoggedIn, nps.results);
+	app.post('/updatenps', isLoggedIn, nps.update);
 
 	//sus routes
 	app.get('/createsus', isLoggedIn, sus.create);

--- a/server/study_server.js
+++ b/server/study_server.js
@@ -9,6 +9,9 @@ function renderPages(study,responseID,responseObj){
         case 'sus':
             responseObj.render('sus/view.ejs',{singleStudy: study, response: responseID});
             break;
+        case 'nps':
+            responseObj.render('nps/view.ejs',{singleStudy: study, response: responseID});
+            break;
         case 'cardsort':
             responseObj.render('cardsort/view.ejs',{singleStudy: study, response: responseID});
             break;

--- a/views/nps/edit.ejs
+++ b/views/nps/edit.ejs
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<%- include('../partials/header.ejs') %>
+		<title><%= title %> NPS</title>
+		<!-- Include javascript for private.ejs -->
+		<script src="/clipboard/clipboard.min.js"></script>
+		<script type="text/javascript" src="/js/private.js"></script>
+	</head>
+	<body>
+	<%- include('../partials/admin_header.ejs') %>
+	<div class="container">
+		<%- include('../partials/editwarning.ejs') %>
+		<%if (title == 'Edit') { %>
+		<a href='/studies'><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
+		<% } else {%>
+		<a href="/deletestudy/<%= singleStudy._id %>"><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
+		<% } %>
+		<h1><%= title %> NPS</h1>
+		<hr>
+		<form method="POST" action="/updatenps">
+			<input hidden name='id' value='<%= singleStudy._id %>' />
+			<div class='row'>
+				<div class='col-sm-4'>
+					<%- include('../partials/study_options/title.ejs') %>
+				</div>
+			</div>
+			<div class='row'>
+				<div class="col-sm-3">
+						<%- include('../partials/study_options/status.ejs') %>
+				</div>
+				<div class="col-sm-9">
+					<div class="well">
+						<%- include('../partials/study_options/private.ejs') %>
+					</div>
+				</div>
+			</div>
+			<div class='row'>
+				<div class='col-sm-4'>
+					<button type="submit" class="btn btn-primary">Save</button>
+					<%if (title == 'Edit') { %>
+					<a href="/studies" class="btn btn-default" role="button">Cancel</a>
+					<% } else {%>
+					<a href="/deletestudy/<%= singleStudy._id %>" class="btn btn-default" role="button">Cancel</a>
+					<% } %>
+				</div>
+			</div>
+
+		</form>
+	</div>			
+	<%- include('../partials/footer.ejs') %>
+	</body>
+</html>

--- a/views/nps/edit.ejs
+++ b/views/nps/edit.ejs
@@ -1,53 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<%- include('../partials/header.ejs') %>
-		<title><%= title %> NPS</title>
-		<!-- Include javascript for private.ejs -->
-		<script src="/clipboard/clipboard.min.js"></script>
-		<script type="text/javascript" src="/js/private.js"></script>
-	</head>
-	<body>
-	<%- include('../partials/admin_header.ejs') %>
-	<div class="container">
-		<%- include('../partials/editwarning.ejs') %>
-		<%if (title == 'Edit') { %>
-		<a href='/studies'><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
-		<% } else {%>
-		<a href="/deletestudy/<%= singleStudy._id %>"><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
-		<% } %>
-		<h1><%= title %> NPS</h1>
-		<hr>
-		<form method="POST" action="/updatenps">
-			<input hidden name='id' value='<%= singleStudy._id %>' />
-			<div class='row'>
-				<div class='col-sm-4'>
-					<%- include('../partials/study_options/title.ejs') %>
-				</div>
-			</div>
-			<div class='row'>
-				<div class="col-sm-3">
-						<%- include('../partials/study_options/status.ejs') %>
-				</div>
-				<div class="col-sm-9">
-					<div class="well">
-						<%- include('../partials/study_options/private.ejs') %>
-					</div>
-				</div>
-			</div>
-			<div class='row'>
-				<div class='col-sm-4'>
-					<button type="submit" class="btn btn-primary">Save</button>
-					<%if (title == 'Edit') { %>
-					<a href="/studies" class="btn btn-default" role="button">Cancel</a>
-					<% } else {%>
-					<a href="/deletestudy/<%= singleStudy._id %>" class="btn btn-default" role="button">Cancel</a>
-					<% } %>
-				</div>
-			</div>
+    <head>
+        <%- include('../partials/header.ejs') %>
+        <title><%= title %> NPS</title>
+        <!-- Include javascript for private.ejs -->
+        <script src="/clipboard/clipboard.min.js"></script>
+        <script type="text/javascript" src="/js/private.js"></script>
+    </head>
+    <body>
+    <%- include('../partials/admin_header.ejs') %>
+    <div class="container">
+        <%- include('../partials/editwarning.ejs') %>
+        <%if (title == 'Edit') { %>
+        <a href='/studies'><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
+        <% } else {%>
+        <a href="/deletestudy/<%= singleStudy._id %>"><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
+        <% } %>
+        <h1><%= title %> NPS</h1>
+        <hr>
+        <form method="POST" action="/updatenps">
+            <input hidden name='id' value='<%= singleStudy._id %>' />
+            <div class='row'>
+                <div class='col-sm-4'>
+                    <%- include('../partials/study_options/title.ejs') %>
+                </div>
+            </div>
+            <div class='row'>
+                <div class="col-sm-3">
+                        <%- include('../partials/study_options/status.ejs') %>
+                </div>
+                <div class="col-sm-9">
+                    <div class="well">
+                        <%- include('../partials/study_options/private.ejs') %>
+                    </div>
+                </div>
+            </div>
+            <div class='row'>
+                <div class='col-sm-4'>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <%if (title == 'Edit') { %>
+                    <a href="/studies" class="btn btn-default" role="button">Cancel</a>
+                    <% } else {%>
+                    <a href="/deletestudy/<%= singleStudy._id %>" class="btn btn-default" role="button">Cancel</a>
+                    <% } %>
+                </div>
+            </div>
 
-		</form>
-	</div>			
-	<%- include('../partials/footer.ejs') %>
-	</body>
+        </form>
+    </div>			
+    <%- include('../partials/footer.ejs') %>
+    </body>
 </html>

--- a/views/nps/results.ejs
+++ b/views/nps/results.ejs
@@ -1,47 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<%- include('../partials/header.ejs') %>
-		<%- include('../partials/datatables.ejs') %>
-		<script type="text/javascript" src="/plotlyjs/plotly.min.js"></script>
-		<script type="text/javascript" src="/js/sus-results.js"></script>
-		<title>Net Promoter Score Results</title>
-	</head>
-	<body>
-		<%- include('../partials/admin_header.ejs') %>
-		<div class='container'>
-			<a href='/studies'><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
-			<h1>Results for <%= study.title %></h1>
-			<br>
-			<div class="well">
-				<h3>Net Promotor Score: <strong><%= npsScore.toFixed(1) %></strong></h3>
-			</div>
-			<div class="well">
-				<h3>Scores by Response</h3>
-				<hr>
-				<table id='raw_results_table'>
-					<thead>
-						<tr>
-							<th>Response #</th>
-							<th>Title / Name</th>
-							<th>Date Submitted</th>
-							<th>Response</th>
-							<th>Calculated Result</th>
-						</tr>
-					</thead>
-					<% for(var i=0; i<rawResponses.length; i++) {%>
-						<tr>
-							<td><%= i+1 %></td>
-							<td><%= rawResponses[i].title %></td>
-							<td><%= rawResponses[i].date.toLocaleDateString() %> (<%= rawResponses[i].date.toLocaleTimeString() %>)</td>
-							<% for(var j=0; j<rawResponses[i].data.length; j++) {%>
-								<td><%= JSON.stringify(Number(rawResponses[i].data[j])) %></td>
-							<% } %>
-							<td><%= npsResults[i] %></td>
-						</tr>
-					<% } %>
-				</table>
-			</div>			
-		</div>
-	</body>
+    <head>
+        <%- include('../partials/header.ejs') %>
+        <%- include('../partials/datatables.ejs') %>
+        <script type="text/javascript" src="/plotlyjs/plotly.min.js"></script>
+        <script type="text/javascript" src="/js/sus-results.js"></script>
+        <title>Net Promoter Score Results</title>
+    </head>
+    <body>
+        <%- include('../partials/admin_header.ejs') %>
+        <div class='container'>
+            <a href='/studies'><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
+            <h1>Results for <%= study.title %></h1>
+            <br>
+            <div class="well">
+                <h3>Net Promotor Score: <strong><%= npsScore.toFixed(1) %></strong></h3>
+            </div>
+            <div class="well">
+                <h3>Scores by Response</h3>
+                <hr>
+                <table id='raw_results_table'>
+                    <thead>
+                        <tr>
+                            <th>Response #</th>
+                            <th>Title / Name</th>
+                            <th>Date Submitted</th>
+                            <th>Response</th>
+                            <th>Calculated Result</th>
+                        </tr>
+                    </thead>
+                    <% for(var i=0; i<rawResponses.length; i++) {%>
+                        <tr>
+                            <td><%= i+1 %></td>
+                            <td><%= rawResponses[i].title %></td>
+                            <td><%= rawResponses[i].date.toLocaleDateString() %> (<%= rawResponses[i].date.toLocaleTimeString() %>)</td>
+                            <% for(var j=0; j<rawResponses[i].data.length; j++) {%>
+                                <td><%= JSON.stringify(Number(rawResponses[i].data[j])) %></td>
+                            <% } %>
+                            <td><%= npsResults[i] %></td>
+                        </tr>
+                    <% } %>
+                </table>
+            </div>			
+        </div>
+    </body>
 </html>

--- a/views/nps/results.ejs
+++ b/views/nps/results.ejs
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<%- include('../partials/header.ejs') %>
+		<%- include('../partials/datatables.ejs') %>
+		<script type="text/javascript" src="/plotlyjs/plotly.min.js"></script>
+		<script type="text/javascript" src="/js/sus-results.js"></script>
+		<title>Net Promoter Score Results</title>
+	</head>
+	<body>
+		<%- include('../partials/admin_header.ejs') %>
+		<div class='container'>
+			<a href='/studies'><i class="fa fa-chevron-left icon-sm" aria-hidden="true"></i> Back to Studies</a>
+			<h1>Results for <%= study.title %></h1>
+			<br>
+			<div class="well">
+				<h3>Net Promotor Score: <strong><%= npsScore.toFixed(1) %></strong></h3>
+			</div>
+			<div class="well">
+				<h3>Scores by Response</h3>
+				<hr>
+				<table id='raw_results_table'>
+					<thead>
+						<tr>
+							<th>Response #</th>
+							<th>Title / Name</th>
+							<th>Date Submitted</th>
+							<th>Response</th>
+							<th>Calculated Result</th>
+						</tr>
+					</thead>
+					<% for(var i=0; i<rawResponses.length; i++) {%>
+						<tr>
+							<td><%= i+1 %></td>
+							<td><%= rawResponses[i].title %></td>
+							<td><%= rawResponses[i].date.toLocaleDateString() %> (<%= rawResponses[i].date.toLocaleTimeString() %>)</td>
+							<% for(var j=0; j<rawResponses[i].data.length; j++) {%>
+								<td><%= JSON.stringify(Number(rawResponses[i].data[j])) %></td>
+							<% } %>
+							<td><%= npsResults[i] %></td>
+						</tr>
+					<% } %>
+				</table>
+			</div>			
+		</div>
+	</body>
+</html>

--- a/views/nps/view.ejs
+++ b/views/nps/view.ejs
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<%- include('../partials/header.ejs') %>
+
+		<link rel="stylesheet" type="text/css" href="/css/surveys.css" />
+
+		<nav  style='margin-bottom: 0px;' class="navbar navbar-default navbar-static-top">
+			<div class="container-fluid custom_topbar">
+				<span class='navbar-brand'><%= singleStudy.title %></span>
+			    <ul class='nav navbar-nav'></ul>
+			</div>
+		</nav>
+	</head>
+	<body>		
+		<script type="text/javascript" src="/js/nps.js"/></script>
+
+		<div class='container'>
+			<form method="POST" id="npsForm" action="/submitResult">
+				<input name="resid" id='resid' type='text' hidden value="<%= response %>" />
+				<input name="id" id='id' type='text' hidden value="<%= singleStudy._id %>" />
+				<input name="result" id='hiddenResults' type='text' hidden>
+				<div class="question">
+					<p>On a scale of 0-10, how likely are you to recommend this product or service to a friend or colleague?</p>
+					<table>
+						<tr>
+							<td>0<input class="radio-inline" type="radio" name="1" value=0></td>
+							<td>1<input class="radio-inline" type="radio" name="1" value=1></td>
+							<td>2<input class="radio-inline" type="radio" name="1" value=2></td>
+							<td>3<input class="radio-inline" type="radio" name="1" value=3></td>
+							<td>4<input class="radio-inline" type="radio" name="1" value=4></td>
+							<td>5<input class="radio-inline" type="radio" name="1" value=5></td>
+							<td>6<input class="radio-inline" type="radio" name="1" value=6></td>
+							<td>7<input class="radio-inline" type="radio" name="1" value=7></td>
+							<td>8<input class="radio-inline" type="radio" name="1" value=8></td>
+							<td>9<input class="radio-inline" type="radio" name="1" value=9></td>
+							<td>10<input class="radio-inline" type="radio" name="1" value=10></td>
+						</tr>
+					</table>	
+				</div>
+			</form>
+			<button type="button" id="submitForm" class="btn btn-default disabled">Submit</button>
+		</div>
+	</body>
+</html>

--- a/views/nps/view.ejs
+++ b/views/nps/view.ejs
@@ -1,45 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<%- include('../partials/header.ejs') %>
+    <head>
+        <%- include('../partials/header.ejs') %>
 
-		<link rel="stylesheet" type="text/css" href="/css/surveys.css" />
+        <link rel="stylesheet" type="text/css" href="/css/surveys.css" />
 
-		<nav  style='margin-bottom: 0px;' class="navbar navbar-default navbar-static-top">
-			<div class="container-fluid custom_topbar">
-				<span class='navbar-brand'><%= singleStudy.title %></span>
-			    <ul class='nav navbar-nav'></ul>
-			</div>
-		</nav>
-	</head>
-	<body>		
-		<script type="text/javascript" src="/js/nps.js"/></script>
+        <nav  style='margin-bottom: 0px;' class="navbar navbar-default navbar-static-top">
+            <div class="container-fluid custom_topbar">
+                <span class='navbar-brand'><%= singleStudy.title %></span>
+                <ul class='nav navbar-nav'></ul>
+            </div>
+        </nav>
+    </head>
+    <body>		
+        <script type="text/javascript" src="/js/nps.js"/></script>
 
-		<div class='container'>
-			<form method="POST" id="npsForm" action="/submitResult">
-				<input name="resid" id='resid' type='text' hidden value="<%= response %>" />
-				<input name="id" id='id' type='text' hidden value="<%= singleStudy._id %>" />
-				<input name="result" id='hiddenResults' type='text' hidden>
-				<div class="question">
-					<p>On a scale of 0-10, how likely are you to recommend this product or service to a friend or colleague?</p>
-					<table>
-						<tr>
-							<td>0<input class="radio-inline" type="radio" name="1" value=0></td>
-							<td>1<input class="radio-inline" type="radio" name="1" value=1></td>
-							<td>2<input class="radio-inline" type="radio" name="1" value=2></td>
-							<td>3<input class="radio-inline" type="radio" name="1" value=3></td>
-							<td>4<input class="radio-inline" type="radio" name="1" value=4></td>
-							<td>5<input class="radio-inline" type="radio" name="1" value=5></td>
-							<td>6<input class="radio-inline" type="radio" name="1" value=6></td>
-							<td>7<input class="radio-inline" type="radio" name="1" value=7></td>
-							<td>8<input class="radio-inline" type="radio" name="1" value=8></td>
-							<td>9<input class="radio-inline" type="radio" name="1" value=9></td>
-							<td>10<input class="radio-inline" type="radio" name="1" value=10></td>
-						</tr>
-					</table>	
-				</div>
-			</form>
-			<button type="button" id="submitForm" class="btn btn-default disabled">Submit</button>
-		</div>
-	</body>
+        <div class='container'>
+            <form method="POST" id="npsForm" action="/submitResult">
+                <input name="resid" id='resid' type='text' hidden value="<%= response %>" />
+                <input name="id" id='id' type='text' hidden value="<%= singleStudy._id %>" />
+                <input name="result" id='hiddenResults' type='text' hidden>
+                <div class="question">
+                    <p>On a scale of 0-10, how likely are you to recommend this product or service to a friend or colleague?</p>
+                    <table>
+                        <tr>
+                            <td>0<input class="radio-inline" type="radio" name="1" value=0></td>
+                            <td>1<input class="radio-inline" type="radio" name="1" value=1></td>
+                            <td>2<input class="radio-inline" type="radio" name="1" value=2></td>
+                            <td>3<input class="radio-inline" type="radio" name="1" value=3></td>
+                            <td>4<input class="radio-inline" type="radio" name="1" value=4></td>
+                            <td>5<input class="radio-inline" type="radio" name="1" value=5></td>
+                            <td>6<input class="radio-inline" type="radio" name="1" value=6></td>
+                            <td>7<input class="radio-inline" type="radio" name="1" value=7></td>
+                            <td>8<input class="radio-inline" type="radio" name="1" value=8></td>
+                            <td>9<input class="radio-inline" type="radio" name="1" value=9></td>
+                            <td>10<input class="radio-inline" type="radio" name="1" value=10></td>
+                        </tr>
+                    </table>	
+                </div>
+            </form>
+            <button type="button" id="submitForm" class="btn btn-default disabled">Submit</button>
+        </div>
+    </body>
 </html>

--- a/views/overview.ejs
+++ b/views/overview.ejs
@@ -72,6 +72,20 @@
 					</ul>
 				</div>
 			</div>
+			<hr>
+			<div class="row">
+				<div class="col-sm-8">
+					<h3 class="header">Net Promoter Score (NPS)</h3>
+					<p>The Net Promoter Score (NPS) is a measure to indicate the willingness of customers to recommend your product or service to others. NPS is a single question that asks the participant how likely they are to recommend a product/service on a scale of 0-10. The scale is divided between detractors (1-6), passives (7 or 8), and promoters (9 or 10).</p>
+				</div>
+				<div class="col-sm-4">
+					<p>Learn more:</p>
+					<ul>
+						<li><a target="_blank" href="https://www.netpromoter.com/know/">What is Net Promoter? - Net Promoter Network</a></li>
+						<li><a target="_blank" href="https://en.wikipedia.org/wiki/Net_Promoter">Net Promoter - Wikipedia</a></li>
+					</ul>
+				</div>
+			</div>
 		</div>
 	<!-- <%- include('partials/footer.ejs') %> -->
 	</body>

--- a/views/studies.ejs
+++ b/views/studies.ejs
@@ -29,8 +29,8 @@
 				      <li><a href="/createcardsort">Card Sort</a></li>
 				      <li><a href="/createtreetest">Tree Test</a></li>
 				      <li><a href="/createproductreactioncards">Product Reaction Cards</a></li>
-					  <li><a href="/createsus">System Usability Scale (SUS)</a></li>
-					  <li><a href="/createnps">Net Promoter Score (NPS)</a></li>
+				      <li><a href="/createsus">System Usability Scale (SUS)</a></li>
+				      <li><a href="/createnps">Net Promoter Score (NPS)</a></li>
 				    </ul>
 			  	</div>
 			</div>

--- a/views/studies.ejs
+++ b/views/studies.ejs
@@ -29,7 +29,8 @@
 				      <li><a href="/createcardsort">Card Sort</a></li>
 				      <li><a href="/createtreetest">Tree Test</a></li>
 				      <li><a href="/createproductreactioncards">Product Reaction Cards</a></li>
-				      <li><a href="/createsus">System Usability Scale (SUS)</a></li>
+					  <li><a href="/createsus">System Usability Scale (SUS)</a></li>
+					  <li><a href="/createnps">Net Promoter Score (NPS)</a></li>
 				    </ul>
 			  	</div>
 			</div>
@@ -94,6 +95,15 @@
 								<td><a class="btn btn-link" href="/editsus/<%= studies[i]._id %>">Edit</a></td>
 								<td><a class="btn btn-link" href="/sus/preview/<%= studies[i]._id %>">Preview</a></td>
 						<% } %>
+						<%if (studies[i].type == 'nps') { %>
+								<%if (studies[i].completeResponses.length > 0) { %>									
+									<td><a class="btn btn-link" href="/npsresults/<%= studies[i]._id %>">Results</a></td>
+								<% } else { %>
+									<td></td>
+								<% } %>
+								<td><a class="btn btn-link" href="/editnps/<%= studies[i]._id %>">Edit</a></td>
+								<td><a class="btn btn-link" href="/nps/preview/<%= studies[i]._id %>">Preview</a></td>
+						<% } %>	
 						<td>
 							<div class="btn-group">
 							    <button type="button" style="color:darkgray" class=" btn btn-link dropdown-toggle" data-toggle="dropdown"><i class="fa fa-lg fa-ellipsis-h" aria-hidden="true"></i></button>

--- a/views/sus/view.ejs
+++ b/views/sus/view.ejs
@@ -3,7 +3,7 @@
 	<head>
 		<%- include('../partials/header.ejs') %>
 
-		<link rel="stylesheet" type="text/css" href="/css/sus.css" />
+		<link rel="stylesheet" type="text/css" href="/css/surveys.css" />
 
 		<nav  style='margin-bottom: 0px;' class="navbar navbar-default navbar-static-top">
 			<div class="container-fluid custom_topbar">


### PR DESCRIPTION
User can now create a 'Net Promoter Score' study in the same way that they would create other studies and view the resulting score as users submit responses.

Comments:
- A future enhancement for the NPS study type could be to allow the user to specify the product/service that they're testing in order to better articulate the context of the question. I thought it would be worth a discussion so I didn't include it in this PR.
- Currently, adding a new study type requires adding conditional code to pages to support that new study type (i.e. 'js/studies.js', 'views/studies.ejs', 'server/study_server.js'). If there are intentions to expand to additional study types, we could store some of this information in the 'study' database model and potentially create a new database model: 'study type'.

closes #116 